### PR TITLE
resolve std name conflict

### DIFF
--- a/relacy/relacy_std.hpp
+++ b/relacy/relacy_std.hpp
@@ -19,64 +19,68 @@
 
 namespace std
 {
-//    using rl::memory_order;
-    using rl::mo_relaxed;
-    using rl::mo_consume;
-    using rl::mo_acquire;
-    using rl::mo_release;
-    using rl::mo_acq_rel;
-    using rl::mo_seq_cst;
+    namespace rlimp {
+      using namespace rl;
+    }
 
-    using rl::atomic;
-    using rl::atomic_thread_fence;
-    using rl::atomic_signal_fence;
+    #define memory_order rlimp::memory_order
+    #define mo_relaxed rlimp::mo_relaxed
+    #define mo_consume rlimp::mo_consume
+    #define mo_acquire rlimp::mo_acquire
+    #define mo_release rlimp::mo_release
+    #define mo_acq_rel rlimp::mo_acq_rel
+    #define mo_seq_cst rlimp::mo_seq_cst
 
-    using rl::atomic_bool;
-    using rl::atomic_address;
+    #define atomic rlimp::atomic
+    #define atomic_thread_fence rlimp::atomic_thread_fence
+    #define atomic_signal_fence rlimp::atomic_signal_fence
 
-    using rl::atomic_char;
-    using rl::atomic_schar;
-    using rl::atomic_uchar;
-    using rl::atomic_short;
-    using rl::atomic_ushort;
-    using rl::atomic_int;
-    using rl::atomic_uint;
-    using rl::atomic_long;
-    using rl::atomic_ulong;
-    using rl::atomic_llong;
-    using rl::atomic_ullong;
-//    using rl::atomic_char16_t;
-//    using rl::atomic_char32_t;
-    using rl::atomic_wchar_t;
+    #define atomic_bool rlimp::atomic_bool
+    #define atomic_address rlimp::atomic_address
 
-//    using rl::atomic_int_least8_t;
-//    using rl::atomic_uint_least8_t;
-//    using rl::atomic_int_least16_t;
-//    using rl::atomic_uint_least16_t;
-//    using rl::atomic_int_least32_t;
-//    using rl::atomic_uint_least32_t;
-//    using rl::atomic_int_least64_t;
-//    using rl::atomic_uint_least64_t;
-//    using rl::atomic_int_fast8_t;
-//    using rl::atomic_uint_fast8_t;
-//    using rl::atomic_int_fast16_t;
-//    using rl::atomic_uint_fast16_t;
-//    using rl::atomic_int_fast32_t;
-//    using rl::atomic_uint_fast32_t;
-//    using rl::atomic_int_fast64_t;
-//    using rl::atomic_uint_fast64_t;
-    using rl::atomic_intptr_t;
-    using rl::atomic_uintptr_t;
-    using rl::atomic_size_t;
-//    using rl::atomic_ssize_t;
-    using rl::atomic_ptrdiff_t;
-//    using rl::atomic_intmax_t;
-//    using rl::atomic_uintmax_t;
+    #define atomic_char rlimp::atomic_char
+    #define atomic_schar rlimp::atomic_schar
+    #define atomic_uchar rlimp::atomic_uchar
+    #define atomic_short rlimp::atomic_short
+    #define atomic_ushort rlimp::atomic_ushort
+    #define atomic_int rlimp::atomic_int
+    #define atomic_uint rlimp::atomic_uint
+    #define atomic_long rlimp::atomic_long
+    #define atomic_ulong rlimp::atomic_ulong
+    #define atomic_llong rlimp::atomic_llong
+    #define atomic_ullong rlimp::atomic_ullong
+//    #define atomic_char16_t rlimp::atomic_char16_t
+//    #define atomic_char32_t rlimp::atomic_char32_t
+    #define atomic_wchar_t rlimp::atomic_wchar_t
 
-    using rl::mutex;
-    using rl::recursive_mutex;
-    using rl::condition_variable;
-    using rl::condition_variable_any;
+//    #define atomic_int_least8_t rlimp::atomic_int_least8_t
+//    #define atomic_uint_least8_t rlimp::atomic_uint_least8_t
+//    #define atomic_int_least16_t rlimp::atomic_int_least16_t
+//    #define atomic_uint_least16_t rlimp::atomic_uint_least16_t
+//    #define atomic_int_least32_t rlimp::atomic_int_least32_t
+//    #define atomic_uint_least32_t rlimp::atomic_uint_least32_t
+//    #define atomic_int_least64_t rlimp::atomic_int_least64_t
+//    #define atomic_uint_least64_t rlimp::atomic_uint_least64_t
+//    #define atomic_int_fast8_t rlimp::atomic_int_fast8_t
+//    #define atomic_uint_fast8_t rlimp::atomic_uint_fast8_t
+//    #define atomic_int_fast16_t rlimp::atomic_int_fast16_t
+//    #define atomic_uint_fast16_t rlimp::atomic_uint_fast16_t
+//    #define atomic_int_fast32_t rlimp::atomic_int_fast32_t
+//    #define atomic_uint_fast32_t rlimp::atomic_uint_fast32_t
+//    #define atomic_int_fast64_t rlimp::atomic_int_fast64_t
+//    #define atomic_uint_fast64_t rlimp::atomic_uint_fast64_t
+    #define atomic_intptr_t rlimp::atomic_intptr_t
+    #define atomic_uintptr_t rlimp::atomic_uintptr_t
+    #define atomic_size_t rlimp::atomic_size_t
+//    #define atomic_ssize_t rlimp::atomic_ssize_t
+    #define atomic_ptrdiff_t rlimp::atomic_ptrdiff_t
+//    #define atomic_intmax_t rlimp::atomic_intmax_t
+//    #define atomic_uintmax_t mutex rlimp::atomic_uintmax_t
+
+    #define mutex rlimp::mutex
+    #define recursive_mutex rlimp::recursive_mutex
+    #define condition_variable rlimp::condition_variable
+    #define condition_variable_any rlimp::condition_variable_any
 }
 
 #endif

--- a/relacy/relacy_std.hpp
+++ b/relacy/relacy_std.hpp
@@ -19,7 +19,7 @@
 
 namespace std
 {
-    using rl::memory_order;
+//    using rl::memory_order;
     using rl::mo_relaxed;
     using rl::mo_consume;
     using rl::mo_acquire;


### PR DESCRIPTION
Due to forward declarations and the structure of std includes I had compiler warning for redeclaring some atomic structures.
Here is a possible solution using defines and an internal namespace in std.