### PR TITLE
Fix coherent-read-read issue by changing from last_seen_order_ to first_seen_order_

### DIFF
--- a/relacy/atomic.hpp
+++ b/relacy/atomic.hpp
@@ -671,7 +671,7 @@ struct atomic_data_impl : atomic_data
     struct history_record
     {
         timestamp_t acq_rel_order_ [thread_count];
-        timestamp_t last_seen_order_ [thread_count];
+        timestamp_t first_seen_order_ [thread_count];
 
         bool busy_;
         bool seq_cst_;
@@ -710,8 +710,8 @@ struct atomic_data_impl : atomic_data
         rec.acq_rel_timestamp_ = th.own_acq_rel_order_;
 
         foreach<thread_count>(rec.acq_rel_order_, assign_zero);
-        foreach<thread_count>(rec.last_seen_order_, assign<(timestamp_t)-1>);
-        rec.last_seen_order_[th.index_] = th.own_acq_rel_order_;
+        foreach<thread_count>(rec.first_seen_order_, assign<(timestamp_t)-1>);
+        rec.first_seen_order_[th.index_] = th.own_acq_rel_order_;
     }
 };
 

--- a/relacy/thread.hpp
+++ b/relacy/thread.hpp
@@ -372,7 +372,7 @@ private:
         atomic_data_impl<thread_count>& var = 
             *static_cast<atomic_data_impl<thread_count>*>(data);
         timestamp_t const first_seen = var.history_[var.current_index_ % atomic_history_size].first_seen_order_[index_];
-        aba = (first_seen > own_acq_rel_order_);
+        aba = ((timestamp_t)-1 == first_seen);
         atomic_load<mo, true>(data);
         unsigned result = atomic_store<mo, true>(data);
 

--- a/relacy/thread.hpp
+++ b/relacy/thread.hpp
@@ -273,9 +273,8 @@ private:
         RL_VERIFY(rec.busy_);
 
         own_acq_rel_order_ += 1;
-        if ((timestamp_t)-1 == rec.first_seen_order_[index_]) {
+        if ((timestamp_t)-1 == rec.first_seen_order_[index_])
             rec.first_seen_order_[index_] = own_acq_rel_order_;
-        }
 
         bool const synch =
             (mo_acquire == mo

--- a/relacy/thread.hpp
+++ b/relacy/thread.hpp
@@ -229,6 +229,12 @@ private:
                 if (acq_rel_order >= rec.acq_rel_timestamp_)
                     break;
 
+                //  This check ensures read-read coherence, 1.10/16:
+                //  If a value computation A of an atomic object M happens before a value
+                //  computation B of M, and A takes its value from a side effect X on M,
+                //  then the value computed by B shall either be the value stored by X or
+                //  the value stored by a side effect Y on M, where Y follows X in the
+                //  modification order of M. 
                 bool stop = false;
                 for (thread_id_t i = 0; i != thread_count; ++i)
                 {

--- a/relacy/thread.hpp
+++ b/relacy/thread.hpp
@@ -217,7 +217,7 @@ private:
                     return (unsigned)-1; // access to unitialized var
 
                 history_t const& prev = var.history_[(index - 1) % atomic_history_size];
-                if (prev.busy_ && prev.last_seen_order_[index_] <= last_yield_)
+                if (prev.busy_ && prev.first_seen_order_[index_] <= last_yield_)
                     break;
 
                 if (mo_seq_cst == val(mo) && rec.seq_cst_)
@@ -233,7 +233,7 @@ private:
                 for (thread_id_t i = 0; i != thread_count; ++i)
                 {
                     timestamp_t acq_rel_order2 = acq_rel_order_[i];
-                    if (acq_rel_order2 >= rec.last_seen_order_[i])
+                    if (acq_rel_order2 >= rec.first_seen_order_[i])
                     {
                         stop = true;
                         break;
@@ -273,7 +273,9 @@ private:
         RL_VERIFY(rec.busy_);
 
         own_acq_rel_order_ += 1;
-        rec.last_seen_order_[index_] = own_acq_rel_order_;
+        if ((timestamp_t)-1 == rec.first_seen_order_[index_]) {
+            rec.first_seen_order_[index_] = own_acq_rel_order_;
+        }
 
         bool const synch =
             (mo_acquire == mo
@@ -329,9 +331,9 @@ private:
         own_acq_rel_order_ += 1;
         rec.acq_rel_timestamp_ = own_acq_rel_order_;
 
-        foreach<thread_count>(rec.last_seen_order_, assign<(timestamp_t)-1>);
+        foreach<thread_count>(rec.first_seen_order_, assign<(timestamp_t)-1>);
 
-        rec.last_seen_order_[index_] = own_acq_rel_order_;
+        rec.first_seen_order_[index_] = own_acq_rel_order_;
 
         unsigned const prev_idx = (var.current_index_ - 1) % atomic_history_size;
         history_t& prev = var.history_[prev_idx];
@@ -369,8 +371,8 @@ private:
     {
         atomic_data_impl<thread_count>& var = 
             *static_cast<atomic_data_impl<thread_count>*>(data);
-        timestamp_t const last_seen = var.history_[var.current_index_ % atomic_history_size].last_seen_order_[index_];
-        aba = (last_seen > own_acq_rel_order_);
+        timestamp_t const first_seen = var.history_[var.current_index_ % atomic_history_size].first_seen_order_[index_];
+        aba = (first_seen > own_acq_rel_order_);
         atomic_load<mo, true>(data);
         unsigned result = atomic_store<mo, true>(data);
 

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -391,6 +391,7 @@ int main()
         &rl::simulate<test_pthread_condvar2>,
         &rl::simulate<test_pthread_sem>,
         
+        &rl::simulate<coherent_read_read_test>,
         &rl::simulate<order_relaxed_test<0> >,
         &rl::simulate<order_relaxed_test<1> >,
         &rl::simulate<order_relaxed_test<2> >,

--- a/test/memory_order.hpp
+++ b/test/memory_order.hpp
@@ -2,6 +2,35 @@
 
 #include "../relacy/relacy_std.hpp"
 
+struct coherent_read_read_test : rl::test_suite<coherent_read_read_test, 3>
+{
+    std::atomic<int> x;
+    std::atomic<int> y;
+
+    void before()
+    {
+        x($) = 0;
+        y($) = 0;
+    }
+
+    void thread(unsigned th)
+    {
+        if (0 == th) {
+            x.store(1, rl::memory_order_relaxed);    
+        } else if (1 == th) {
+            if (0 == x.load(rl::memory_order_relaxed)) {
+                return;
+            }
+            y.store(1, rl::memory_order_release);
+            x.load(rl::memory_order_relaxed);
+        } else {
+            if (0 == y.load(rl::memory_order_acquire)) {
+                return;
+            }
+            RL_ASSERT(1 == x.load(rl::memory_order_relaxed));
+        }
+    }
+};
 
 
 template<int index>

--- a/test/memory_order.hpp
+++ b/test/memory_order.hpp
@@ -15,18 +15,19 @@ struct coherent_read_read_test : rl::test_suite<coherent_read_read_test, 3>
 
     void thread(unsigned th)
     {
-        if (0 == th) {
-            x.store(1, rl::memory_order_relaxed);    
-        } else if (1 == th) {
-            if (0 == x.load(rl::memory_order_relaxed)) {
+        if (0 == th)
+            x.store(1, rl::memory_order_relaxed);
+        else if (1 == th)
+        {
+            if (0 == x.load(rl::memory_order_relaxed))
                 return;
-            }
             y.store(1, rl::memory_order_release);
             x.load(rl::memory_order_relaxed);
-        } else {
-            if (0 == y.load(rl::memory_order_acquire)) {
+        }
+        else
+        {
+            if (0 == y.load(rl::memory_order_acquire))
                 return;
-            }
             RL_ASSERT(1 == x.load(rl::memory_order_relaxed));
         }
     }
@@ -139,7 +140,7 @@ struct acq_rel_test : rl::test_suite<acq_rel_test, 2>
 
 
 template<int index>
-struct seq_cst_test : rl::test_suite<seq_cst_test<index>, 4, 
+struct seq_cst_test : rl::test_suite<seq_cst_test<index>, 4,
     (rl::test_result_e)((1 - index) * rl::test_result_until_condition_hit)>
 {
     std::atomic<int> x1;


### PR DESCRIPTION
I noticed that relacy can be made not to respect coherent read-read due to the fact that each record maintains _last_ seen order instead of _first_ seen order. I have added a test case in test/memory_order.hpp to show how this can happen. Maintaining _first_ seen order instead of _last_ seen order prevents two loads from getting entries in the modification history that are backwards relative to the ordering of the loads. 

I don't believe any other logic is impacted by switching from first to last seen. The only other place last_seen is used is in setting the value of aba in atomic_rmw. The existing comparison for aba is effectively comparing against (timestamp_t)-1, so it should not matter whether first or last seen is used. I've also updated the comparison to reflect this.

Am I missing an important reason why last seen order must be maintained instead of first seen order? If I am, is there a way to fix the coherent read-read issue? 

Thanks! 