### PR TITLE
Fix build with libc++ (macOS)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ script:
   - make check
 
 install:
-  - CXX="${RELACY_CXX}"; export CXX; unset RELACY_CXX; export RELACY_CXX
+  - CXX="${RELACY_CXX:-${CXX}}"; export CXX; unset RELACY_CXX; export RELACY_CXX
   - ${CXX} --version
 
 matrix:
@@ -31,6 +31,15 @@ matrix:
     - addons: { apt: { packages: ["clang-7"], sources: ["llvm-toolchain-trusty-7", "ubuntu-toolchain-r-test"] } }
       env: RELACY_CXX=clang++-7
       os: linux
+
+    - os: osx
+      osx_image: xcode8.3
+
+    - os: osx
+      osx_image: xcode9.4
+
+    - os: osx
+      osx_image: xcode10.1
 
 dist: trusty
 language: cpp

--- a/relacy/defs.hpp
+++ b/relacy/defs.hpp
@@ -131,7 +131,7 @@ struct set
 template<typename T, typename Y>
 struct map
 {
-    typedef std::map<T, Y, std::less<T>, raw_allocator<std::pair<T, Y> > > type;
+    typedef std::map<T, Y, std::less<T>, raw_allocator<std::pair<const T, Y> > > type;
 };
 
 typedef std::basic_string<char, std::char_traits<char>, raw_allocator<char> > string;


### PR DESCRIPTION
libc++ asserts that a correct allocator type is given to std::map. Relacy fails this assertion:

    static_assert failed due to requirement 'is_same<typename allocator_type::value_type, value_type>::value' "Allocator::value_type must be same type as value_type"

Fix the error by giving a `std::pair<const T, Y>` allocator, matching `std::map<T, V>::value_type`.

This commit should not change behavior.