### PR TITLE
change hash_map_t key type for gcc v8

### DIFF
--- a/relacy/context_addr_hash.hpp
+++ b/relacy/context_addr_hash.hpp
@@ -51,16 +51,16 @@ private:
         uintptr_t       ptr_;
         size_t          hash_;
     };
-    typedef map<void const*, size_t>::type  hash_map_t;
+    typedef map<void* const, size_t>::type  hash_map_t;
     hash_map_t                              hash_map_;
     size_t                                  hash_seq_;
 
-    virtual size_t      get_addr_hash               (void const* p)
+    virtual size_t      get_addr_hash               (const void* p)
     {
         //!!! accept 'table size' to do 'hash % table_size'
         // will give more information for state exploration
 
-        hash_map_t::iterator iter (hash_map_.find(p));
+        hash_map_t::iterator iter (hash_map_.find(const_cast<void*>(p)));
         if (iter != hash_map_.end() && iter->first == p)
         {
             return iter->second;
@@ -69,7 +69,7 @@ private:
         {
             //!!! distribute hashes more randomly, use rand()
             size_t hash = hash_seq_++;
-            hash_map_.insert(std::make_pair(p, hash));
+            hash_map_.insert(std::make_pair(const_cast<void*>(p), hash));
             return hash;
         }
     }

--- a/relacy/memory.hpp
+++ b/relacy/memory.hpp
@@ -89,7 +89,7 @@ public:
             return true;
 
 #ifndef RL_GC
-        map<void*, size_t>::type::iterator iter = allocs_.find(pp);
+        map<void* const, size_t>::type::iterator iter = allocs_.find(pp);
         if (allocs_.end() == iter)
             return false;
 
@@ -152,8 +152,8 @@ public:
     void output_allocs(std::ostream& stream)
     {
         stream << "memory allocations:" << std::endl;
-        map<void*, size_t>::type::iterator iter = allocs_.begin();
-        map<void*, size_t>::type::iterator end = allocs_.end();
+        map<void* const, size_t>::type::iterator iter = allocs_.begin();
+        map<void* const, size_t>::type::iterator end = allocs_.end();
         for (; iter != end; ++iter)
         {
             stream << iter->first << " [" << (unsigned)iter->second << "]" << std::endl;
@@ -175,7 +175,7 @@ private:
     size_t deferred_free_size_ [deferred_count];
 
 #ifndef RL_GC
-    map<void*, size_t>::type allocs_;
+    map<void* const, size_t>::type allocs_;
 #else
     struct alloc_desc_t
     {


### PR DESCRIPTION
Hello!

I didn't know about relacy before. Will surely use it in the future.

While compiling with `gcc version 8.2.1` on Linux, `GNU libc 2.28`, I've
encountered following errors:

`error: static assertion failed: std::map must have the same value_type as its allocator`

```cpp
/usr/include/c++/8.2.1/bits/stl_map.h: In instantiation of ‘class std::map<const void*, long unsigned int, std::less<const void*>, rl::raw_allocator<std::pair<const void*, long unsigned int> > >’:
../subprojects/base_library/gitmodules/relacy/relacy/context_addr_hash.hpp:55:45:   required from here
/usr/include/c++/8.2.1/bits/stl_map.h:122:21: error: static assertion failed: std::map must have the same value_type as its allocator

```

Tried to fix them by swapping `map<void const*, ...>` keys to `map<void* const, ...>`. Not sure if this is the best we can do. 

Thanks!