### PR TITLE
Fix performance bug in thread_local_var

### DIFF
--- a/relacy/thread_local.hpp
+++ b/relacy/thread_local.hpp
@@ -114,6 +114,10 @@ public:
 
     ~thread_local_var()
     {
+        if (is_ctx() && ctx_seq_ == ctx().get_ctx_seq())
+        {
+            generic_thread_local::deinit($);
+        }
     }
 
     thread_local_proxy<T> operator () (debug_info_param info)

--- a/relacy/thread_local_ctx.hpp
+++ b/relacy/thread_local_ctx.hpp
@@ -68,8 +68,7 @@ private:
 
     virtual int         thread_local_alloc          (void (*dtor)(intptr_t))
     {
-        int index = (int)entries_.size();
-        entries_.resize(index + 1);
+        int index = find_or_make_unused_entry_index();
         entry& ent = entries_[index];
         ent.alive_ = true;
         ent.dtor_ = dtor;
@@ -112,6 +111,20 @@ private:
         entry& ent = entries_[index];
         RL_VERIFY(ent.alive_);
         return ent.value_[current_thread()];
+    }
+
+    int find_or_make_unused_entry_index()
+    {
+        int index;
+        for (index = 0; index < (int)entries_.size(); ++index)
+        {
+            if (!entries_[index].alive_)
+            {
+                return (int)index;
+            }
+        }
+        entries_.resize(index + 1);
+        return index;
     }
 };
 


### PR DESCRIPTION
thread_local_var has a poor performance if a thread_local_var object is created each test iteration. This poor performance is caused by some oversights:

* thread_local_ctx::thread_local_alloc always grows the entries_ vector, even if an entry is unallocated (i.e. thread_local_free was previously called). The entries_ vector is not cleared between iterations either. This causes O(iteration) memory usage (due to the entries_ vector), and adds O(iteration^2) time overhead (in iteration_begin).
* thread_local_var::~thread_local_var never calls thread_local_ctx::thread_local_free. This means that, even if the above issue was fixed, the performance bugs might persist.

Squash both of these bugs:

* Make thread_local_var::~thread_local_var call thread_local_ctx::thread_local_free if necessary.
* Make thread_local_ctx::thread_local_alloc reuse freed entries.

Unfortunately, this commit has one negative consequence: Win32-style Tls use-after-free is undetected in some cases.