### PR TITLE
Fix atomic cv pointer stores

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,5 @@
 # Relacy Race Detector
 Meticulous synchronization algorithm verifier for relaxed memory models
 
-http://www.1024cores.net/home/relacy-race-detector
-http://www.1024cores.net/home/relacy-race-detector/rrd-introduction
+ * http://www.1024cores.net/home/relacy-race-detector
+ * http://www.1024cores.net/home/relacy-race-detector/rrd-introduction

--- a/relacy/atomic_events.hpp
+++ b/relacy/atomic_events.hpp
@@ -35,7 +35,7 @@ template<typename T>
 struct atomic_add_type<T*>
 {
     typedef ptrdiff_t type;
-    typedef void* output_type;
+    typedef copy_cv_t<T, void>* output_type;
 };
 
 

--- a/relacy/base.hpp
+++ b/relacy/base.hpp
@@ -108,6 +108,21 @@ T val(T x)
     return x;
 }
 
+template <class From, class To, template <class> class CheckTrait, template <class> class AddTrait>
+struct copy_trait_impl {
+    using type = std::conditional_t<
+        CheckTrait<From>::value,
+        typename AddTrait<To>::type,
+        To>;
+};
+
+template <class From, class To>
+using copy_volatile_t = typename copy_trait_impl<From, To, std::is_volatile, std::add_volatile>::type;
+template <class From, class To>
+using copy_const_t = typename copy_trait_impl<From, To, std::is_const, std::add_const>::type;
+template <class From, class To>
+using copy_cv_t = copy_volatile_t<From, copy_const_t<From, To>>;
+
 }
 
 

--- a/test/memory_order.hpp
+++ b/test/memory_order.hpp
@@ -412,4 +412,29 @@ struct occasional_test : rl::test_suite<occasional_test, 3, rl::test_result_unti
 };
 
 
+struct ensure_atomic_pointer_stores_compile {
+    static void test() {
+        // Ensure the below atomic store expression compile.
+        {
+            rl::atomic<int*> x;
+            int* p = nullptr;
+            x($).store(p);
+        }
+        {
+            rl::atomic<const int*> x;
+            int* p = nullptr;
+            x($).store(p);
+        }
+        {
+            rl::atomic<volatile int*> x;
+            int* p = nullptr;
+            x($).store(p);
+        }
+        {
+            rl::atomic<volatile const int*> x;
+            int* p = nullptr;
+            x($).store(p);
+        }
+    }
+};
 


### PR DESCRIPTION
The new test code fails to compile without proper handling for cv qualified atomic pointer types.