### PR TITLE
Default debug information in C++20, fix spec for atomic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ build_dir = build
 .SECONDARY:
 
 example_programs = cli_ws_deque
-test_programs = ntest/ntest
+test_programs = ntest/ntest defaulted_debug_info atomic_init
 
 example_exe_files = $(foreach name,$(example_programs),$(build_dir)/example/$(name)/$(name))
 test_exe_files = $(foreach name,$(test_programs),$(build_dir)/test/$(name))

--- a/relacy/atomic.hpp
+++ b/relacy/atomic.hpp
@@ -44,7 +44,7 @@ public:
     {
     }
 
-    T load(memory_order mo = mo_seq_cst) const
+    T load(memory_order mo = mo_seq_cst) const noexcept
     {
         return var_.load(mo, info_);
     }
@@ -75,108 +75,108 @@ public:
     {
     }
 
-    void store(T value, memory_order mo = mo_seq_cst)
+    void store(T value, memory_order mo = mo_seq_cst) noexcept
     {
         this->var_.store(value, mo, this->info_);
     }
 
-    bool compare_exchange_weak(T& cmp, T xchg, memory_order mo = mo_seq_cst)
+    bool compare_exchange_weak(T& cmp, T xchg, memory_order mo = mo_seq_cst) noexcept
     {
         return this->var_.compare_exchange(bool_t<true>(), cmp, xchg, mo, this->info_);
     }
 
-    bool compare_exchange_weak(T& cmp, T xchg, memory_order mo, memory_order failure_mo)
+    bool compare_exchange_weak(T& cmp, T xchg, memory_order mo, memory_order failure_mo) noexcept
     {
         return this->var_.compare_exchange(bool_t<true>(), cmp, xchg, mo, failure_mo, this->info_);
     }
 
-    bool compare_exchange_strong(T& cmp, T xchg, memory_order mo = mo_seq_cst)
+    bool compare_exchange_strong(T& cmp, T xchg, memory_order mo = mo_seq_cst) noexcept
     {
         return this->var_.compare_exchange(bool_t<false>(), cmp, xchg, mo, this->info_);
     }
 
-    bool compare_exchange_strong(T& cmp, T xchg, memory_order mo, memory_order failure_mo)
+    bool compare_exchange_strong(T& cmp, T xchg, memory_order mo, memory_order failure_mo) noexcept
     {
         return this->var_.compare_exchange(bool_t<false>(), cmp, xchg, mo, failure_mo, this->info_);
     }
 
-    T exchange(T xchg, memory_order mo = mo_seq_cst)
+    T exchange(T xchg, memory_order mo = mo_seq_cst) noexcept
     {
         return this->var_.rmw(rmw_type_t<rmw_type_swap>(), xchg, mo, this->info_);
     }
 
-    T fetch_add(add_type value, memory_order mo = mo_seq_cst)
+    T fetch_add(add_type value, memory_order mo = mo_seq_cst) noexcept
     {
         return this->var_.rmw(rmw_type_t<rmw_type_add>(), value, mo, this->info_);
     }
 
-    T fetch_sub(add_type value, memory_order mo = mo_seq_cst)
+    T fetch_sub(add_type value, memory_order mo = mo_seq_cst) noexcept
     {
         return this->var_.rmw(rmw_type_t<rmw_type_sub>(), value, mo, this->info_);
     }
 
-    T fetch_and(T value, memory_order mo = mo_seq_cst)
+    T fetch_and(T value, memory_order mo = mo_seq_cst) noexcept
     {
         return this->var_.rmw(rmw_type_t<rmw_type_and>(), value, mo, this->info_);
     }
 
-    T fetch_or(T value, memory_order mo = mo_seq_cst)
+    T fetch_or(T value, memory_order mo = mo_seq_cst) noexcept
     {
         return this->var_.rmw(rmw_type_t<rmw_type_or>(), value, mo, this->info_);
     }
 
-    T fetch_xor(T value, memory_order mo = mo_seq_cst)
+    T fetch_xor(T value, memory_order mo = mo_seq_cst) noexcept
     {
         return this->var_.rmw(rmw_type_t<rmw_type_xor>(), value, mo, this->info_);
     }
 
-    T operator = (T value)
+    T operator = (T value) noexcept
     {
         store(value);
         return value;
     }
 
-    T operator ++ (int)
+    T operator ++ (int) noexcept
     {
         return fetch_add(1);
     }
 
-    T operator -- (int)
+    T operator -- (int) noexcept
     {
         return fetch_sub(1);
     }
 
-    T operator ++ ()
+    T operator ++ () noexcept
     {
         return fetch_add(1) + 1;
     }
 
-    T operator -- ()
+    T operator -- () noexcept
     {
         return fetch_sub(1) - 1;
     }
 
-    T operator += (add_type value)
+    T operator += (add_type value) noexcept
     {
         return fetch_add(value) + value;
     }
 
-    T operator -= (add_type value)
+    T operator -= (add_type value) noexcept
     {
         return fetch_sub(value) + value;
     }
 
-    T operator &= (T value)
+    T operator &= (T value) noexcept
     {
         return fetch_and(value) & value;
     }
 
-    T operator |= (T value)
+    T operator |= (T value) noexcept
     {
         return fetch_or(value) | value;
     }
 
-    T operator ^= (T value)
+    T operator ^= (T value) noexcept
     {
         return fetch_xor(value) ^ value;
     }
@@ -223,7 +223,7 @@ public:
     }
 
     RL_INLINE
-    T load(memory_order mo, debug_info_param info) const
+    T load(memory_order mo DEFAULTED_ATOMIC_OP_MO, debug_info_param info DEFAULTED_DEBUG_INFO) const noexcept
     {
         RL_VERIFY(mo_release != mo);
         RL_VERIFY(mo_acq_rel != mo);
@@ -242,7 +242,7 @@ public:
     }
 
     RL_INLINE
-    void store(T v, memory_order mo, debug_info_param info)
+    void store(T v, memory_order mo DEFAULTED_ATOMIC_OP_MO, debug_info_param info DEFAULTED_DEBUG_INFO) noexcept
     {
         RL_VERIFY(mo_acquire != mo);
         RL_VERIFY(mo_acq_rel != mo);
@@ -259,32 +259,32 @@ public:
     }
 
     RL_INLINE
-    bool compare_exchange_weak(T& cmp, T xchg, memory_order mo, debug_info_param info)
+    bool compare_exchange_weak(T& cmp, T xchg, memory_order mo DEFAULTED_ATOMIC_OP_MO, debug_info_param info DEFAULTED_DEBUG_INFO) noexcept
     {
         return compare_exchange(bool_t<true>(), cmp, xchg, mo, info);
     }
 
     RL_INLINE
-    bool compare_exchange_strong(T& cmp, T xchg, memory_order mo, debug_info_param info)
+    bool compare_exchange_strong(T& cmp, T xchg, memory_order mo DEFAULTED_ATOMIC_OP_MO, debug_info_param info DEFAULTED_DEBUG_INFO) noexcept
     {
         return compare_exchange(bool_t<false>(), cmp, xchg, mo, info);
     }
 
     RL_INLINE
-    bool compare_exchange_weak(T& cmp, T xchg, memory_order mo, debug_info_param info, memory_order failure_mo, debug_info_param)
+    bool compare_exchange_weak(T& cmp, T xchg, memory_order mo, debug_info_param info, memory_order failure_mo, debug_info_param DEFAULTED_DEBUG_INFO) noexcept
     {
         return compare_exchange(bool_t<true>(), cmp, xchg, mo, failure_mo, info);
     }
 
     RL_INLINE
-    bool compare_exchange_strong(T& cmp, T xchg, memory_order mo, debug_info_param info, memory_order failure_mo, debug_info_param)
+    bool compare_exchange_strong(T& cmp, T xchg, memory_order mo, debug_info_param info, memory_order failure_mo, debug_info_param DEFAULTED_DEBUG_INFO) noexcept
     {
         return compare_exchange(bool_t<false>(), cmp, xchg, mo, failure_mo, info);
     }
 
     template<bool spurious_failures>
     RL_INLINE
-    bool compare_exchange(bool_t<spurious_failures>, T& cmp, T xchg, memory_order mo, debug_info_param info)
+    bool compare_exchange(bool_t<spurious_failures>, T& cmp, T xchg, memory_order mo, debug_info_param info) noexcept
     {
         switch (mo)
         {
@@ -366,32 +366,32 @@ public:
         return false;
     }
 
-    T exchange(T xchg, memory_order mo, debug_info_param info)
+    T exchange(T xchg, memory_order mo DEFAULTED_ATOMIC_OP_MO, debug_info_param info DEFAULTED_DEBUG_INFO) noexcept
     {
         return rmw(rmw_type_t<rmw_type_swap>(), xchg, mo, info);
     }
 
-    T fetch_add(typename atomic_add_type<T>::type value, memory_order mo, debug_info_param info)
+    T fetch_add(typename atomic_add_type<T>::type value, memory_order mo DEFAULTED_ATOMIC_OP_MO, debug_info_param info DEFAULTED_DEBUG_INFO) noexcept
     {
         return rmw(rmw_type_t<rmw_type_add>(), value, mo, info);
     }
 
-    T fetch_sub(typename atomic_add_type<T>::type value, memory_order mo, debug_info_param info)
+    T fetch_sub(typename atomic_add_type<T>::type value, memory_order mo DEFAULTED_ATOMIC_OP_MO, debug_info_param info DEFAULTED_DEBUG_INFO) noexcept
     {
         return rmw(rmw_type_t<rmw_type_sub>(), value, mo, info);
     }
 
-    T fetch_and(T value, memory_order mo, debug_info_param info)
+    T fetch_and(T value, memory_order mo DEFAULTED_ATOMIC_OP_MO, debug_info_param info DEFAULTED_DEBUG_INFO) noexcept
     {
         return rmw(rmw_type_t<rmw_type_and>(), value, mo, info);
     }
 
-    T fetch_or(T value, memory_order mo, debug_info_param info)
+    T fetch_or(T value, memory_order mo DEFAULTED_ATOMIC_OP_MO, debug_info_param info DEFAULTED_DEBUG_INFO) noexcept
     {
         return rmw(rmw_type_t<rmw_type_or>(), value, mo, info);
     }
 
-    T fetch_xor(T value, memory_order mo, debug_info_param info)
+    T fetch_xor(T value, memory_order mo DEFAULTED_ATOMIC_OP_MO, debug_info_param info DEFAULTED_DEBUG_INFO) noexcept
     {
         return rmw(rmw_type_t<rmw_type_xor>(), value, mo, info);
     }
@@ -582,7 +582,12 @@ private:
 
 
 template<typename T>
+#if __cplusplus >= 202002L
+// atomic's default constructor value initializes since C++20
+class atomic : public generic_atomic<T, true>
+#else
 class atomic : public generic_atomic<T, false>
+#endif
 {
 public:
     atomic()

--- a/relacy/base.hpp
+++ b/relacy/base.hpp
@@ -128,6 +128,13 @@ using copy_cv_t = copy_volatile_t<From, copy_const_t<From, To>>;
 
 #include "defs.hpp"
 
+#if __cplusplus >= 202002L
+#define DEFAULTED_DEBUG_INFO = std::source_location::current()
+#define DEFAULTED_ATOMIC_OP_MO = mo_seq_cst
+#else
+#define DEFAULTED_DEBUG_INFO
+#define DEFAULTED_ATOMIC_OP_MO
+#endif
 
 #define RL_INFO ::rl::debug_info(__FUNCTION__, __FILE__, __LINE__)
 #define $ RL_INFO

--- a/relacy/defs.hpp
+++ b/relacy/defs.hpp
@@ -13,6 +13,7 @@
 #   pragma once
 #endif
 
+#include <source_location>
 
 namespace rl
 {
@@ -58,6 +59,16 @@ struct debug_info
         , line_(line)
     {
     }
+
+#if __cplusplus >= 202002L
+    debug_info(std::source_location sl) noexcept
+        : func_(sl.function_name())
+        , file_(sl.file_name())
+        , line_(sl.line())
+    {
+    }
+#endif
+
 };
 
 typedef debug_info const& debug_info_param;

--- a/relacy/pch.hpp
+++ b/relacy/pch.hpp
@@ -48,6 +48,7 @@
 #include <map>
 #include <new>
 #include <type_traits>
+#include <source_location>
 
 #if defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
 #   define RL_WIN

--- a/relacy/stdlib/condition_variable.hpp
+++ b/relacy/stdlib/condition_variable.hpp
@@ -311,49 +311,49 @@ public:
         condvar<tag_t>::deinit($);
     }
 
-    void notify_one(debug_info_param info)
+    void notify_one(debug_info_param info DEFAULTED_DEBUG_INFO)
     {
         condvar<tag_t>::notify_one(info);
     }
 
-    void notify_all(debug_info_param info)
+    void notify_all(debug_info_param info DEFAULTED_DEBUG_INFO)
     {
         condvar<tag_t>::notify_all(info);
     }
 
     template<typename lock_t>
-    void wait(lock_t& lock, debug_info_param info)
+    void wait(lock_t& lock, debug_info_param info DEFAULTED_DEBUG_INFO)
     {
         condvar<tag_t>::wait(lock, false, info);
     }
 
     template<typename lock_t, typename pred_t>
-    void wait(lock_t& lock, pred_t pred, debug_info_param info)
+    void wait(lock_t& lock, pred_t pred, debug_info_param info DEFAULTED_DEBUG_INFO)
     {
         condvar<tag_t>::wait(lock, pred, false, info);
     }
 
     template<typename lock_t, typename abs_time_t>
-    bool wait_until(lock_t& lock, abs_time_t const&, debug_info_param info)
+    bool wait_until(lock_t& lock, abs_time_t const&, debug_info_param info DEFAULTED_DEBUG_INFO)
     {
         return condvar<tag_t>::wait(lock, true, info);
     }
 
     template<typename lock_t, typename abs_time_t, typename pred_t>
-    bool wait_until(lock_t& lock, abs_time_t const&, pred_t pred, debug_info_param info)
+    bool wait_until(lock_t& lock, abs_time_t const&, pred_t pred, debug_info_param info DEFAULTED_DEBUG_INFO)
     {
         return condvar<tag_t>::wait(lock, pred, true, info);
     }
     
     template<typename lock_t, typename rel_time_t>
-    bool wait_for(lock_t& lock, rel_time_t const&, debug_info_param info)
+    bool wait_for(lock_t& lock, rel_time_t const&, debug_info_param info DEFAULTED_DEBUG_INFO)
     {
         sema_wakeup_reason reason = condvar<tag_t>::wait(lock, true, info);
         return reason == sema_wakeup_reason_success;
     }
 
     template<typename lock_t, typename rel_time_t, typename pred_t>
-    bool wait_for(lock_t& lock, rel_time_t const&, pred_t pred, debug_info_param info)
+    bool wait_for(lock_t& lock, rel_time_t const&, pred_t pred, debug_info_param info DEFAULTED_DEBUG_INFO)
     {
         return condvar<tag_t>::wait(lock, pred, true, info);
     }

--- a/relacy/stdlib/mutex.hpp
+++ b/relacy/stdlib/mutex.hpp
@@ -645,17 +645,17 @@ public:
         generic_mutex<tag>::deinit($);
     }
 
-    void lock(debug_info_param info)
+    void lock(debug_info_param info DEFAULTED_DEBUG_INFO)
     {
         generic_mutex<tag>::lock_exclusive(info);
     }
 
-    bool try_lock(debug_info_param info)
+    bool try_lock(debug_info_param info DEFAULTED_DEBUG_INFO)
     {
         return generic_mutex<tag>::try_lock_exclusive(info);
     }
 
-    void unlock(debug_info_param info)
+    void unlock(debug_info_param info DEFAULTED_DEBUG_INFO)
     {
         generic_mutex<tag>::unlock_exclusive(info);
     }

--- a/test/atomic_init.cpp
+++ b/test/atomic_init.cpp
@@ -1,0 +1,29 @@
+#include "../relacy/relacy_std.hpp"
+
+#if __cplusplus >= 202002L
+struct atomic_init_test : rl::test_suite<atomic_init_test, 1>
+{
+    void thread(unsigned index)
+    {
+        rl::atomic<int> i;
+        i($).load();
+    }
+};
+#else
+struct atomic_init_test : rl::test_suite<atomic_init_test, 1, rl::test_result_unitialized_access>
+{
+    void thread(unsigned index)
+    {
+        rl::atomic<int> i;
+        i($).load();
+    }
+};
+#endif
+
+int main()
+{
+    rl::test_params p;
+    p.iteration_count = 1;
+    rl::simulate<atomic_init_test>();
+    return 0;
+}

--- a/test/defaulted_debug_info.cpp
+++ b/test/defaulted_debug_info.cpp
@@ -1,0 +1,43 @@
+#if __cplusplus >= 202002L
+
+#include "../relacy/relacy_std.hpp"
+
+struct defaulted_debug_info_test : rl::test_suite<defaulted_debug_info_test, 1>
+{
+    void thread(unsigned index)
+    {
+        // Verify that calling member methods without passing the `$` argument
+        // explicitly compiles C++20 mode. In C++20 mode, the debug_info_param
+        // is defaulted with std::source_location.
+
+        rl::mutex mtx;
+        rl::condition_variable cv;
+        rl::atomic<int> i;
+
+        i.store(0);
+        int expected = 0;
+        i.compare_exchange_strong(expected, 1);
+        i.exchange(1);
+
+        if (i.load() == 100) {
+            mtx.lock();
+            cv.wait(mtx);
+            mtx.unlock();
+        } else {
+            cv.notify_all();
+            cv.notify_one();
+        }
+    }
+};
+
+int main()
+{
+    rl::test_params p;
+    p.iteration_count = 1000;
+    rl::simulate<defaulted_debug_info_test>();
+    return 0;
+}
+
+#else
+int main() { return 0; }
+#endif


### PR DESCRIPTION
Relacy requires changing the source code under test to add the debug information with the `$` macro, e.g., `cv.notify($)`. With C++20's `std::source_location`, we can default the debug parameter. This allows the code under test to spell `cv.notify()` while still being passed the correct file/line/function debug information.

Additionally, this commit fixes the spec for std::atomic<int> to
 - use noexcept for members like store, load
 - atomic's constructor in C++20 value initializes T

Test plan: Verified build with the following on a Linux environment

```
CXX_STD=c++11 make clean && make -j $(nproc) all
CXX_STD=c++20 make clean && make -j $(nproc) all
```