### PR TITLE
Fix move assignment, construct thread_impl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 # User-customizable variables:
 CXX ?= c++
 CXX_STD ?= c++11
-CXXFLAGS ?= -I relacy/fakestd -O1 -std=$(CXX_STD)
+#CXXFLAGS ?= -I relacy/fakestd -O1 -std=$(CXX_STD)
+CXXFLAGS ?= -I relacy/fakestd -O0 -std=$(CXX_STD) -I stdexec/include -I stdexec/test -g -fsanitize=memory -fsanitize-memory-track-origins -fno-omit-frame-pointer  -nostdinc -I/opt/rh/devtoolset-11/root/usr/lib/gcc/x86_64-redhat-linux/11/../../../../include/c++/11 -I/opt/rh/devtoolset-11/root/usr/lib/gcc/x86_64-redhat-linux/11/../../../../include/c++/11/x86_64-redhat-linux -I/opt/rh/devtoolset-11/root/usr/lib/gcc/x86_64-redhat-linux/11/../../../../include/c++/11/backward -I/opt/rh/devtoolset-11/root/usr/lib/gcc/x86_64-redhat-linux/11/include -I/usr/local/include -I/opt/rh/devtoolset-11/root/usr/include -I/usr/include
 DEPFLAGS ?= -MD -MF $(@).d -MP -MT $(@)
 build_dir = build
 

--- a/relacy/atomic.hpp
+++ b/relacy/atomic.hpp
@@ -198,6 +198,8 @@ public:
         value_ = T();
         already_failed_ = false;
 
+        memset(history_, 0, sizeof(history_));
+
         if (val(strong_init))
         {
             unsigned const index = c.threadx_->atomic_init(impl_);
@@ -692,6 +694,8 @@ struct atomic_data_impl : atomic_data
 
     atomic_data_impl()
     {
+        memset(history_, 0, sizeof(history_));
+
         current_index_ = 0;
         history_record& rec = history_[0];
         history_[atomic_history_size - 1].busy_ = false;

--- a/relacy/fakestd/thread
+++ b/relacy/fakestd/thread
@@ -19,6 +19,9 @@ struct thread {
         bool operator==(const id& other) const {
             return id_ == other.id_;
         }
+        bool operator!=(const id& other) const {
+            return !(*this == other);
+        }
         long id_;
     };
     static unsigned int hardware_concurrency() noexcept { return 1; }
@@ -28,6 +31,7 @@ struct thread {
     }
     template <class F> thread(F&& fn, rl::debug_info info DEFAULTED_DEBUG_INFO) {
         impl_ = (thread_impl*)malloc(sizeof(thread_impl));
+        new (impl_) thread_impl{};
         impl_->fn = (F&&)fn;
         rl_pthread_create(&impl_->handle, nullptr, thread_fn, impl_, info, &impl_->tid);
     }
@@ -35,7 +39,7 @@ struct thread {
     thread(thread&& other) : impl_(rl::exchange(other.impl_, nullptr)) {
     }
     thread& operator=(thread&& other) noexcept {
-        if (this == &other) {
+        if (this != &other) {
             impl_ = rl::exchange(other.impl_, nullptr);
         }
         return *this;

--- a/relacy/fakestd/thread
+++ b/relacy/fakestd/thread
@@ -46,6 +46,7 @@ struct thread {
     }
     ~thread() {
         if (impl_) {
+            impl_->~thread_impl();
             free(impl_);
         }
     }

--- a/test/cxx11_thread.cpp
+++ b/test/cxx11_thread.cpp
@@ -24,10 +24,34 @@ struct cxx11_thread_tests : rl::test_suite<cxx11_thread_tests, 1>
     }
 };
 
+struct cxx11_thread_basic_ops_test : rl::test_suite<cxx11_thread_basic_ops_test, 1>
+{
+    static size_t const dynamic_thread_count = 1;
+
+    void thread(unsigned index)
+    {
+        {
+            // Verify we can create an empty thread and safely destroy it
+            std::thread t;
+        }
+
+        {
+            // Verify move ctor and move assignment.
+            std::thread a{[] {}, $};
+            RL_ASSERT(std::this_thread::get_id() != a.get_id());
+            std::thread b = std::move(a);
+            RL_ASSERT(std::this_thread::get_id() != b.get_id());
+            a = std::move(b);
+            RL_ASSERT(std::this_thread::get_id() != a.get_id());
+        }
+    }
+};
+
 int main()
 {
     rl::test_params p;
     p.iteration_count = 1000;
     rl::simulate<cxx11_thread_tests>(p);
+    rl::simulate<cxx11_thread_basic_ops_test>(p);
     return 0;
 }


### PR DESCRIPTION
Fix move assignment, and add test that exposed the bug.

Also fix default constructing and destrucrting a `std::thread`, along with a test that exposed the bug (which was a random crash due to the `std::function` construct never being called).

Finally, atomic.hpp's `history_` is updated to be zero-initialized after MSAN reported an uninitialized memory read.

```
==11872==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x55f772a853ed in unsigned int rl::thread_info<2>::get_load_index<(rl::memory_order)0, false>(rl::atomic_data_impl<2>&) /home/ccotter/git/relacy/test/../relacy/thread.hpp:220:21
    #1 0x55f772a83d17 in unsigned int rl::thread_info<2>::atomic_load<(rl::memory_order)0, false>(rl::atomic_data*) /home/ccotter/git/relacy/test/../relacy/thread.hpp:273:26
    #2 0x55f772a7a382 in rl::thread_info<2>::atomic_load_relaxed(rl::atomic_data*) /home/ccotter/git/relacy/test/../relacy/thread.hpp:134:16
    #3 0x55f772b196df in int rl::generic_atomic<int, true>::load_impl<(rl::memory_order)0, &rl::thread_info_base::atomic_load_relaxed(rl::atomic_data*)>(rl::debug_info const&) const /home/ccotter/git/relacy/test/../relacy/atomic.hpp:449:36
    #4 0x55f772b18d08 in rl::generic_atomic<int, true>::load(rl::memory_order, rl::debug_info const&) const /home/ccotter/git/relacy/test/../relacy/atomic.hpp:235:33
    #5 0x55f772b0fc4f in test_FlushProcessWriteBuffers::thread(unsigned int) /home/ccotter/git/relacy/test/windows.hpp:329:21
    #6 0x55f772a69344 in rl::context_impl<test_FlushProcessWriteBuffers, rl::random_scheduler<2>>::fiber_proc_impl(int) /home/ccotter/git/relacy/test/../relacy/context.hpp:482:37
    #7 0x55f772a5f24f in rl::context_impl<test_FlushProcessWriteBuffers, rl::random_scheduler<2>>::fiber_proc(void*) /home/ccotter/git/relacy/test/../relacy/context.hpp:1046:11
    #8 0x55f772953ce5 in fiber_start_fnc(void*) /home/ccotter/git/relacy/test/../relacy/platform.hpp:189:5
    #9 0x7f4c1d77118f  (/lib64/libc.so.6+0x4818f) (BuildId: 2df8053b3adc8934cfeb0f11c1322ec6948085d5)

  Uninitialized value was created by a heap allocation
    #0 0x55f77291c3dd in malloc /tmp/compiler-rt-17.0-17.0.6-2/lib/msan/msan_interceptors.cpp:955:3

SUMMARY: MemorySanitizer: use-of-uninitialized-value /home/ccotter/git/relacy/test/../relacy/thread.hpp:220:21 in unsigned int rl::thread_info<2>::get_load_index<(rl::memory_order)0, false>(rl::atomic_data_impl<2>&)
```