### PR TITLE
Fix memory related bugs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,14 @@
 # User-customizable variables:
 CXX ?= c++
 CXX_STD ?= c++11
-#CXXFLAGS ?= -I relacy/fakestd -O1 -std=$(CXX_STD)
-CXXFLAGS ?= -I relacy/fakestd -O0 -std=$(CXX_STD) -I stdexec/include -I stdexec/test -g -fsanitize=memory -fsanitize-memory-track-origins -fno-omit-frame-pointer  -nostdinc -I/opt/rh/devtoolset-11/root/usr/lib/gcc/x86_64-redhat-linux/11/../../../../include/c++/11 -I/opt/rh/devtoolset-11/root/usr/lib/gcc/x86_64-redhat-linux/11/../../../../include/c++/11/x86_64-redhat-linux -I/opt/rh/devtoolset-11/root/usr/lib/gcc/x86_64-redhat-linux/11/../../../../include/c++/11/backward -I/opt/rh/devtoolset-11/root/usr/lib/gcc/x86_64-redhat-linux/11/include -I/usr/local/include -I/opt/rh/devtoolset-11/root/usr/include -I/usr/include
+CXXFLAGS ?= -I relacy/fakestd -O1 -std=$(CXX_STD)
 DEPFLAGS ?= -MD -MF $(@).d -MP -MT $(@)
 build_dir = build
 
 .SECONDARY:
 
 example_programs = cli_ws_deque
-test_programs = ntest/ntest defaulted_debug_info atomic_init cxx11_thread
+test_programs = ntest/ntest defaulted_debug_info atomic_init cxx11_thread new_delete
 
 example_exe_files = $(foreach name,$(example_programs),$(build_dir)/example/$(name)/$(name))
 test_exe_files = $(foreach name,$(test_programs),$(build_dir)/test/$(name))

--- a/relacy/context.hpp
+++ b/relacy/context.hpp
@@ -1278,6 +1278,16 @@ inline void operator delete (void* p) throw()
         (::free)(p);
 }
 
+#ifdef __cpp_sized_deallocation
+inline void operator delete (void* p, size_t sz) noexcept
+{
+    if (rl::is_ctx())
+        rl::ctx().free(p);
+    else
+        (::free)(p);
+}
+#endif
+
 inline void operator delete [] (void* p) throw()
 {
     if (rl::is_ctx())
@@ -1285,6 +1295,16 @@ inline void operator delete [] (void* p) throw()
     else
         (::free)(p);
 }
+
+#ifdef __cpp_sized_deallocation
+inline void operator delete [] (void* p, size_t sz) noexcept
+{
+    if (rl::is_ctx())
+        rl::ctx().free(p);
+    else
+        (::free)(p);
+}
+#endif
 
 #define RL_NEW_PROXY rl::new_proxy($) % new
 #define RL_DELETE_PROXY rl::delete_proxy($) , delete

--- a/relacy/stdlib/mutex.hpp
+++ b/relacy/stdlib/mutex.hpp
@@ -28,7 +28,7 @@ namespace std {
     template <class T>
     struct lock_guard {
         T& mtx_;
-        rl::debug_info_param info_;
+        rl::debug_info info_;
         lock_guard(const lock_guard&) = delete;
         lock_guard& operator=(const lock_guard&) = delete;
         lock_guard(T& mtx, rl::debug_info_param info DEFAULTED_DEBUG_INFO) : mtx_(mtx), info_(info) {
@@ -42,7 +42,7 @@ namespace std {
     template <class T>
     struct unique_lock {
         T& mtx_;
-        rl::debug_info_param info_;
+        rl::debug_info info_;
         bool locked_ = true;
         unique_lock(const unique_lock&) = delete;
         unique_lock& operator=(const unique_lock&) = delete;

--- a/test/new_delete.cpp
+++ b/test/new_delete.cpp
@@ -1,0 +1,23 @@
+#include "../../relacy/relacy_std.hpp"
+#include "../../relacy/relacy_cli.hpp"
+
+#include <vector>
+
+struct new_delete_tests : rl::test_suite<new_delete_tests, 1>
+{
+    void thread(unsigned index)
+    {
+        std::vector<int> vs;
+        vs.push_back(1);
+        vs.push_back(2);
+        vs.push_back(3);
+    }
+};
+
+int main()
+{
+    rl::test_params p;
+    p.iteration_count = 10;
+    rl::simulate<new_delete_tests>(p);
+    return 0;
+}


### PR DESCRIPTION
 * Use debug_info for data members instead of debug_info_param (which is a reference). Caught by ASAN.
 * Supply C++14 overloads for operator delete, which may be called by the standard library. Without these overloads, some deallocations are not intercepted by relacy, and can lead to malloc/free mismatches.