### PR TITLE
Misc fixes/enhancements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,13 @@ build_dir = build
 .SECONDARY:
 
 example_programs = cli_ws_deque
-test_programs = ntest/ntest defaulted_debug_info atomic_init cxx11_thread new_delete
+test_programs = \
+	ntest/ntest \
+	defaulted_debug_info \
+	atomic_init \
+	cxx11_thread \
+	new_delete \
+	debug_info
 
 example_exe_files = $(foreach name,$(example_programs),$(build_dir)/example/$(name)/$(name))
 test_exe_files = $(foreach name,$(test_programs),$(build_dir)/test/$(name))

--- a/relacy/defs.hpp
+++ b/relacy/defs.hpp
@@ -53,7 +53,7 @@ struct debug_info
     char const* file_;
     unsigned line_;
 
-    debug_info(char const* func = "", char const* file = "", unsigned line = 0)
+    debug_info(char const* func = "", char const* file = "", unsigned line = 0) noexcept
         : func_(func)
         , file_(file)
         , line_(line)

--- a/relacy/fakestd/stop_token
+++ b/relacy/fakestd/stop_token
@@ -1,0 +1,6 @@
+// -*-C++-*-
+
+#ifndef INCLUDED_RL_STOP_TOKEN
+#define INCLUDED_RL_STOP_TOKEN
+
+#endif

--- a/relacy/relacy.hpp
+++ b/relacy/relacy.hpp
@@ -53,8 +53,14 @@
 #define memory_order_seq_cst mo_seq_cst, $
 #endif
 
+// The 'delete' keyword can be used to remove compiler provided methods,
+// e.g., 'SomeClass() = delete;' and does not play well when defining
+// the macro below. Use RELACY_ENABLE_NEW_DELETE_PROXY to enable
+// the new/delete proxies.
+#ifdef RELACY_ENABLE_NEW_DELETE_PROXY
 #define new                 RL_NEW_PROXY
 #define delete              RL_DELETE_PROXY
+#endif
 #define malloc(sz)          rl::rl_malloc((sz), $)
 #define calloc(sz, cnt)     rl::rl_calloc((sz), (cnt), $)
 #define realloc(p, sz)      rl::rl_realloc((p), (sz), $)

--- a/relacy/stdlib/mutex.hpp
+++ b/relacy/stdlib/mutex.hpp
@@ -49,7 +49,7 @@ namespace std {
         unique_lock(T& mtx, rl::debug_info_param info DEFAULTED_DEBUG_INFO) : mtx_(mtx), info_(info) {
             mtx_.lock(info);
         }
-        void lock(rl::debug_info_param info) {
+        void lock(rl::debug_info_param info DEFAULTED_DEBUG_INFO) {
             mtx_.lock(info);
             locked_ = true;
         }

--- a/test/debug_info.cpp
+++ b/test/debug_info.cpp
@@ -1,0 +1,5 @@
+#include "../relacy/relacy_std.hpp"
+int main() {
+    static_assert(noexcept($));
+    return 0;
+}


### PR DESCRIPTION
 * Gate new/delete macros behind RELACY_ENABLE_NEW_DELETE_PROXY. Many standard library includes make use of specifying ` = delete` for destructors, rendering the `define delete` trick impossible to use with programs that include things like `<memory>`, `<vector>`, etc.
 * Add stop_token fake header
 * Mark all debug_info constructors noexcept
 * Default source information for unique_lock::lock()