### PR TITLE
fix compilation errors

### DIFF
--- a/relacy/atomic.hpp
+++ b/relacy/atomic.hpp
@@ -478,7 +478,7 @@ private:
         sign_.check(info);
 
         unsigned const index = (c.threadx_->*impl)(impl_);
-        
+
         T const prev = value_;
         last_index_ = index;
         history_[index] = v;
@@ -729,15 +729,15 @@ struct atomic_flag {
     atomic_flag& operator=(const atomic_flag&) = delete;
 
     void clear(memory_order mo DEFAULTED_ATOMIC_OP_MO, debug_info_param info DEFAULTED_DEBUG_INFO) noexcept {
-        flg.store(false, mo);
+        flg.store(false, mo, info);
     }
 
     bool test_and_set(memory_order mo DEFAULTED_ATOMIC_OP_MO, debug_info_param info DEFAULTED_DEBUG_INFO) {
-        return flg.exchange(true, mo);
+        return flg.exchange(true, mo, info);
     }
 
     bool test(memory_order mo DEFAULTED_ATOMIC_OP_MO, debug_info_param info DEFAULTED_DEBUG_INFO) {
-        return flg.load(mo);
+        return flg.load(mo, info);
     }
 
 private:

--- a/test/condvar.hpp
+++ b/test/condvar.hpp
@@ -58,7 +58,7 @@ struct test_condvar_wait_pred : rl::test_suite<test_condvar_wait_pred, 2>
         }
         else
         {
-            std::unique_lock lock(mtx, $);
+            std::unique_lock<std::mutex> lock(mtx, $);
             cv.wait(mtx, [&] { return 0 != data($); }, $);
         }
     }

--- a/test/debug_info.cpp
+++ b/test/debug_info.cpp
@@ -1,5 +1,5 @@
 #include "../relacy/relacy_std.hpp"
 int main() {
-    static_assert(noexcept($));
+    static_assert(noexcept($), "");
     return 0;
 }

--- a/test/ntest/ntest.cpp
+++ b/test/ntest/ntest.cpp
@@ -197,7 +197,7 @@ struct test_api : rl::test_suite<test_api, 1>
         rl::nvar<int> cv1, cv2(3), cv3(cv1($)), cv4(cv1);
         cv1($) = cv2($);
         cv1($) = 1;
-        (int)cv1($);
+        (void)cv1($);
         cv1($) += 1;
         cv1($) -= 1;
         cv1($)++;


### PR DESCRIPTION
Was trying to compile the library tests.

C++20 mode doesn't seem to work for me period - 

```
/usr/lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/shared_ptr_atomic.h:523:10: error: no template named '__atomic_base'
  523 |         mutable __atomic_base<uintptr_t> _M_val{0};
```

I guess it has to do with "relacy/fakestd" but I'm not sure.

Fixed the C++11/14 compilation.

=====

PS: 

It complains a lot about inline new replacements.

```
example/cli_ws_deque/../../relacy/context.hpp:1257:1: warning: replacement function 'operator new' cannot be declared 'inline' [-Winline-new-delete]
 1257 | inline void* operator new (size_t size) RL_THROW_SPEC(std::bad_alloc)
```

I'm pretty sure it's correct.

Have you maybe considered CATCH2 style approach, where they have a macro to declare one CPP file.

The user just adds: 
```
#define RL_MAIN_FILE
#include <rl/linked_stuff.h>
```

And then you get hooks into new proper.

