### PR TITLE
moving std::lock guard apis to rl

### DIFF
--- a/relacy/relacy_std.hpp
+++ b/relacy/relacy_std.hpp
@@ -77,6 +77,9 @@ namespace std
     using rl::recursive_mutex;
     using rl::condition_variable;
     using rl::condition_variable_any;
+
+    using rl::lock_guard;
+    using rl::unique_lock;
 }
 
 #endif

--- a/relacy/stdlib/condition_variable.hpp
+++ b/relacy/stdlib/condition_variable.hpp
@@ -333,13 +333,13 @@ public:
         condvar<tag_t>::wait(lock, pred, false, info);
     }
 
-    void wait(std::unique_lock<rl::mutex>& lock, debug_info_param info DEFAULTED_DEBUG_INFO)
+    void wait(rl::unique_lock<rl::mutex>& lock, debug_info_param info DEFAULTED_DEBUG_INFO)
     {
         wait(lock.mtx_, info);
     }
 
     template<typename pred_t>
-    void wait(std::unique_lock<rl::mutex>& lock, pred_t pred, debug_info_param info DEFAULTED_DEBUG_INFO)
+    void wait(rl::unique_lock<rl::mutex>& lock, pred_t pred, debug_info_param info DEFAULTED_DEBUG_INFO)
     {
         wait(lock.mtx_, pred, info);
     }
@@ -355,7 +355,7 @@ public:
     {
         return condvar<tag_t>::wait(lock, pred, true, info);
     }
-    
+
     template<typename lock_t, typename rel_time_t>
     bool wait_for(lock_t& lock, rel_time_t const&, debug_info_param info DEFAULTED_DEBUG_INFO)
     {

--- a/relacy/stdlib/mutex.hpp
+++ b/relacy/stdlib/mutex.hpp
@@ -23,53 +23,49 @@
 #include "../foreach.hpp"
 #include "semaphore.hpp"
 
-namespace std {
-
-    template <class T>
-    struct lock_guard {
-        T& mtx_;
-        rl::debug_info info_;
-        lock_guard(const lock_guard&) = delete;
-        lock_guard& operator=(const lock_guard&) = delete;
-        lock_guard(T& mtx, rl::debug_info_param info DEFAULTED_DEBUG_INFO) : mtx_(mtx), info_(info) {
-            mtx_.lock(info_);
-        }
-        ~lock_guard() {
-            mtx_.unlock(info_);
-        }
-    };
-
-    template <class T>
-    struct unique_lock {
-        T& mtx_;
-        rl::debug_info info_;
-        bool locked_ = true;
-        unique_lock(const unique_lock&) = delete;
-        unique_lock& operator=(const unique_lock&) = delete;
-        unique_lock(T& mtx, rl::debug_info_param info DEFAULTED_DEBUG_INFO) : mtx_(mtx), info_(info) {
-            mtx_.lock(info);
-        }
-        void lock(rl::debug_info_param info DEFAULTED_DEBUG_INFO) {
-            mtx_.lock(info);
-            locked_ = true;
-        }
-        void unlock(rl::debug_info_param info DEFAULTED_DEBUG_INFO) {
-            mtx_.unlock(info);
-            locked_ = false;
-        }
-        ~unique_lock() {
-            if (locked_)
-                mtx_.unlock(info_);
-        }
-
-        bool owns_lock() const noexcept { return locked_; }
-        operator bool() const noexcept { return locked_; }
-    };
-
-}
-
 namespace rl
 {
+
+template <class T>
+struct lock_guard {
+    T& mtx_;
+    rl::debug_info info_;
+    lock_guard(const lock_guard&) = delete;
+    lock_guard& operator=(const lock_guard&) = delete;
+    lock_guard(T& mtx, rl::debug_info_param info DEFAULTED_DEBUG_INFO) : mtx_(mtx), info_(info) {
+        mtx_.lock(info_);
+    }
+    ~lock_guard() {
+        mtx_.unlock(info_);
+    }
+};
+
+template <class T>
+struct unique_lock {
+    T& mtx_;
+    rl::debug_info info_;
+    bool locked_ = true;
+    unique_lock(const unique_lock&) = delete;
+    unique_lock& operator=(const unique_lock&) = delete;
+    unique_lock(T& mtx, rl::debug_info_param info DEFAULTED_DEBUG_INFO) : mtx_(mtx), info_(info) {
+        mtx_.lock(info);
+    }
+    void lock(rl::debug_info_param info DEFAULTED_DEBUG_INFO) {
+        mtx_.lock(info);
+        locked_ = true;
+    }
+    void unlock(rl::debug_info_param info DEFAULTED_DEBUG_INFO) {
+        mtx_.unlock(info);
+        locked_ = false;
+    }
+    ~unique_lock() {
+        if (locked_)
+            mtx_.unlock(info_);
+    }
+
+    bool owns_lock() const noexcept { return locked_; }
+    operator bool() const noexcept { return locked_; }
+};
 
 struct generic_mutex_data : nocopy<>
 {


### PR DESCRIPTION
moving lock guards into rl namespace and then reexporting them to std.

Originally @ccotter  added lock guards like this in https://github.com/dvyukov/relacy/pull/23
I don't see an obvious reason for it and there doesn't seem to be a comment as to why.

That breaks very poorly for me - the std lock guard get's pulled in from some transitive header.

If I move the lock_guards into the a  namespace and just export them, I can avoid including the std reexport.

All the tests still pass.