### PR TITLE
Extend support for C++20 atomic, newer GCC/libstdc++

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,12 @@
+Jan 7, 2026
+ - Added more support for GCC12, 13, and 14 with libstdc++
+ - Added support for C++20's std::atomic wait/notify* APIs.
+ - Relacy no longer defines memory_order_* macros to insert the rl::debug_info
+   with the current file/line information. In C++20 mode, Relacy uses
+   std::source_location to do this automatically without relying on macros.
+   As of this release, Relacy introduces RELACY_ENABLE_MEMORY_ORDER_DEBUG_INFO_DEFAULTING
+   to allow using the older behavior, which should only be needed in pre-C++20.
+
 Version 2.4
 Features:
 + Support for futex(FUTEX_WAIT/FUTEX_WAKE) 

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,12 @@
 # User-customizable variables:
 CXX ?= c++
 CXX_STD ?= c++11
-CXXFLAGS ?= -I relacy/fakestd -O1 -std=$(CXX_STD)
+CXXFLAGS ?= -O1 -std=$(CXX_STD)
 DEPFLAGS ?= -MD -MF $(@).d -MP -MT $(@)
-build_dir = build
+build_dir ?= build
+
+# Programs that need the fakestd include path
+programs_needing_fakestd = atomic_wait_notify atomic_init cxx11_thread main
 
 .SECONDARY:
 
@@ -12,6 +15,7 @@ test_programs = \
 	ntest/ntest \
 	defaulted_debug_info \
 	atomic_init \
+	atomic_wait_notify \
 	cxx11_thread \
 	new_delete \
 	debug_info
@@ -65,7 +69,7 @@ $(build_dir)/%: $(build_dir)/%.cpp.o
 
 $(build_dir)/%.cpp.o: %.cpp
 	@mkdir -p $(dir $(@))
-	$(COMPILE.cpp) -o $(@) $(<)
+	$(if $(findstring $(notdir $(basename $(*))).,$(addsuffix .,$(programs_needing_fakestd))),$(COMPILE.cpp) -I relacy/fakestd -o $(@) $(<),$(COMPILE.cpp) -o $(@) $(<))
 
 .PHONY: clean
 clean:

--- a/relacy/atomic_fence.hpp
+++ b/relacy/atomic_fence.hpp
@@ -38,7 +38,7 @@ struct atomic_fence_event
 
 
 RL_INLINE
-void atomic_thread_fence(memory_order mo, debug_info_param info)
+void atomic_thread_fence(memory_order mo, debug_info_param info DEFAULTED_DEBUG_INFO)
 {
     context& c = ctx();
     RL_VERIFY(false == c.invariant_executing);

--- a/relacy/fakestd/bits/atomic_base.h
+++ b/relacy/fakestd/bits/atomic_base.h
@@ -1,6 +1,8 @@
 #ifndef RL_BITS_ATOMIC_BASE
 #define RL_BITS_ATOMIC_BASE
 
+// For C
+
 enum memory_order {
     memory_order_relaxed,
     memory_order_consume,

--- a/relacy/memory_order.hpp
+++ b/relacy/memory_order.hpp
@@ -19,19 +19,46 @@
 namespace rl
 {
 
+    #if __cplusplus >= 202002L
+    
+    enum class memory_order : int
+    {
+        relaxed, consume, acquire, release, acq_rel, seq_cst
+    };
+    inline constexpr memory_order memory_order_relaxed = memory_order::relaxed;
+    inline constexpr memory_order memory_order_consume = memory_order::consume;
+    inline constexpr memory_order memory_order_acquire = memory_order::acquire;
+    inline constexpr memory_order memory_order_release = memory_order::release;
+    inline constexpr memory_order memory_order_acq_rel = memory_order::acq_rel;
+    inline constexpr memory_order memory_order_seq_cst = memory_order::seq_cst;
 
-enum memory_order
-{
-    mo_relaxed,
-    mo_consume,
-    mo_acquire,
-    mo_release,
-    mo_acq_rel,
-    mo_seq_cst,
-};
+    inline constexpr memory_order mo_relaxed = memory_order_relaxed;
+    inline constexpr memory_order mo_consume = memory_order_consume;
+    inline constexpr memory_order mo_acquire = memory_order_acquire;
+    inline constexpr memory_order mo_release = memory_order_release;
+    inline constexpr memory_order mo_acq_rel = memory_order_acq_rel;
+    inline constexpr memory_order mo_seq_cst = memory_order_seq_cst;
 
+    #else
 
+    enum memory_order
+    {
+        memory_order_relaxed,
+        memory_order_consume,
+        memory_order_acquire,
+        memory_order_release,
+        memory_order_acq_rel,
+        memory_order_seq_cst,
+        
+        mo_relaxed = memory_order_relaxed,
+        mo_consume = memory_order_consume,
+        mo_acquire = memory_order_acquire,
+        mo_release = memory_order_release,
+        mo_acq_rel = memory_order_acq_rel,
+        mo_seq_cst = memory_order_seq_cst
+    };
 
+    #endif
 
 inline char const* format(memory_order mo)
 {

--- a/relacy/relacy.hpp
+++ b/relacy/relacy.hpp
@@ -37,6 +37,21 @@
 #define TLS_T(T) rl::thread_local_var<T>
 #define VAR(x) x($)
 
+// Before C++20, to simplify atomic store/load operations without having to specify the
+// '$' debug info macro, the memory_order_* names are defined as macros which specify
+// the '$' macro as the final argument.
+//
+// std::atomicint> a;
+// a.store(memory_order_relaxed); // Will automatically capture $ as the last parameter.
+//
+// Since C++20, relacy's atomic store/load default the debug information without requiring
+// any macros via std::source_location. With C++20 more common, to allow code to use
+// 'std::memory_order_relaxed` without interference from the same name being a macro,
+// by default, the memory_order_* names are not defined as macros. To enable the older
+// behavior, define the RELACY_ENABLE_MEMORY_ORDER_DEBUG_INFO_DEFAULTING macro in the
+// build.
+#ifdef RELACY_ENABLE_MEMORY_ORDER_DEBUG_INFO_DEFAULTING
+
 #ifndef RL_FORCE_SEQ_CST
 #define memory_order_relaxed mo_relaxed, $
 #define memory_order_consume mo_consume, $
@@ -51,6 +66,8 @@
 #define memory_order_release mo_seq_cst, $
 #define memory_order_acq_rel mo_seq_cst, $
 #define memory_order_seq_cst mo_seq_cst, $
+#endif
+
 #endif
 
 // The 'delete' keyword can be used to remove compiler provided methods,

--- a/relacy/relacy_prologue.hpp
+++ b/relacy/relacy_prologue.hpp
@@ -1,0 +1,12 @@
+#ifndef RL_RELACY_PROLOGUE_HPP
+#define RL_RELACY_PROLOGUE_HPP
+
+#if defined(__GNUC__) && __GNUC__ >= 12
+
+// Do not include bits/shared_ptr_atomic.h from libstdc++++
+// It defines its own atomic implementation that conflicts with relacy
+#define _SHARED_PTR_ATOMIC_H
+
+#endif
+
+#endif

--- a/relacy/relacy_std.hpp
+++ b/relacy/relacy_std.hpp
@@ -13,6 +13,7 @@
 #   pragma once
 #endif
 
+#include "relacy_prologue.hpp"
 
 #include "relacy.hpp"
 
@@ -20,6 +21,16 @@
 namespace std
 {
     using rl::memory_order;
+    
+#ifndef RELACY_ENABLE_MEMORY_ORDER_DEBUG_INFO_DEFAULTING
+    using rl::memory_order_relaxed;
+    using rl::memory_order_consume;
+    using rl::memory_order_acquire;
+    using rl::memory_order_release;
+    using rl::memory_order_acq_rel;
+    using rl::memory_order_seq_cst;
+#endif
+
     using rl::mo_relaxed;
     using rl::mo_consume;
     using rl::mo_acquire;

--- a/test/atomic_init.cpp
+++ b/test/atomic_init.cpp
@@ -23,7 +23,6 @@ struct atomic_init_test : rl::test_suite<atomic_init_test, 1, rl::test_result_un
 int main()
 {
     rl::test_params p;
-    p.iteration_count = 1;
-    rl::simulate<atomic_init_test>();
-    return 0;
+    p.iteration_count = 100;
+    return rl::simulate<atomic_init_test>();
 }

--- a/test/atomic_wait_notify.cpp
+++ b/test/atomic_wait_notify.cpp
@@ -1,0 +1,493 @@
+#if __cplusplus >= 202002L
+
+#include "../relacy/relacy_std.hpp"
+
+struct test_atomic_wait_notify_basic : rl::test_suite<test_atomic_wait_notify_basic, 2>
+{
+    std::atomic<int> data;
+
+    void before()
+    {
+        data.store(0);
+    }
+
+    void thread(unsigned index)
+    {
+        if (0 == index)
+        {
+            data.wait(0);
+            RL_ASSERT(data.load() == 1);
+        }
+        else
+        {
+            data.store(1);
+            data.notify_one();
+        }
+    }
+};
+
+struct test_atomic_notify_one_insufficient : rl::test_suite<test_atomic_notify_one_insufficient, 3, rl::test_result_deadlock>
+{
+    std::atomic<int> data;
+
+    void before()
+    {
+        data($).store(0);
+    }
+
+    void thread(unsigned index)
+    {
+        if (index < 2)
+        {
+            data($).wait(0);
+        }
+        else
+        {
+            data($).store(1);
+            data($).notify_one();
+        }
+    }
+};
+
+struct test_atomic_notify_all : rl::test_suite<test_atomic_notify_all, 4>
+{
+    std::atomic<int> data;
+
+    void before()
+    {
+        data.store(0);
+    }
+
+    void thread(unsigned index)
+    {
+        if (index < 3)
+        {
+            data.wait(0);
+        }
+        else
+        {
+            data.store(1);
+            data.notify_all();
+        }
+    }
+};
+
+struct test_atomic_wait_no_block : rl::test_suite<test_atomic_wait_no_block, 2>
+{
+    std::atomic<int> data;
+
+    void before()
+    {
+        data.store(1);
+    }
+
+    void thread(unsigned index)
+    {
+        if (0 == index)
+        {
+            data.wait(0);
+            RL_ASSERT(data.load() == 1);
+        }
+        else
+        {
+            RL_ASSERT(data.load() == 1);
+        }
+    }
+};
+
+struct test_atomic_wait_notify_cycles : rl::test_suite<test_atomic_wait_notify_cycles, 2>
+{
+    std::atomic<int> data;
+
+    void before()
+    {
+        data.store(0);
+    }
+
+    void thread(unsigned index)
+    {
+        if (0 == index)
+        {
+            data.wait(0);
+            RL_ASSERT(data.load() == 1);
+            
+            data.store(2);
+            data.notify_one();
+        }
+        else
+        {
+            data.store(1);
+            data.notify_one();
+            
+            data.wait(1);
+            RL_ASSERT(data.load() == 2);
+        }
+    }
+};
+
+struct test_atomic_notify_no_waiters : rl::test_suite<test_atomic_notify_no_waiters, 2>
+{
+    std::atomic<int> data;
+
+    void before()
+    {
+        data.store(0);
+    }
+
+    void thread(unsigned index)
+    {
+        if (0 == index)
+        {
+            data.store(1);
+            data.notify_one();
+            data.store(2);
+            data.notify_all();
+        }
+        else
+        {
+            while (data.load() < 2) {}
+            RL_ASSERT(data.load() == 2);
+        }
+    }
+};
+
+struct test_atomic_wait_memory_order : rl::test_suite<test_atomic_wait_memory_order, 2>
+{
+    std::atomic<int> flag;
+    rl::var<int> shared_data;
+
+    void before()
+    {
+        flag.store(0);
+        shared_data($) = 0;
+    }
+
+    void thread(unsigned index)
+    {
+        if (0 == index)
+        {
+            flag.wait(0);
+            
+            int val = shared_data($);
+            RL_ASSERT(val == 123);
+        }
+        else
+        {
+            shared_data($) = 123;
+            flag.store(1, rl::memory_order_release);
+            flag.notify_one();
+        }
+    }
+};
+
+
+struct test_atomic_racing_notifiers : rl::test_suite<test_atomic_racing_notifiers, 4>
+{
+    std::atomic<int> data;
+    std::atomic<int> woken;
+
+    void before()
+    {
+        data.store(0);
+        woken.store(0);
+    }
+
+    void thread(unsigned index)
+    {
+        if (index == 0)
+        {
+            data.wait(0);
+            woken.store(1);
+        }
+        else
+        {
+            // Three notifiers
+            data.store(1);
+            data.notify_one();
+        }
+    }
+};
+
+struct test_atomic_wait_race : rl::test_suite<test_atomic_wait_race, 2>
+{
+    std::atomic<int> data;
+
+    void before()
+    {
+        data.store(0);
+    }
+
+    void thread(unsigned index)
+    {
+        if (0 == index)
+        {
+            data.wait(0);
+            RL_ASSERT(data.load() != 0);
+        }
+        else
+        {
+            data.store(1);
+            data.notify_one();
+        }
+    }
+};
+
+struct test_atomic_forgot_notify : rl::test_suite<test_atomic_forgot_notify, 2, rl::test_result_deadlock>
+{
+    std::atomic<int> data;
+
+    void before()
+    {
+        data.store(0);
+    }
+
+    void thread(unsigned index)
+    {
+        if (0 == index)
+        {
+            data.wait(0);
+        }
+        else
+        {
+            data.store(1);
+        }
+    }
+};
+
+struct test_atomic_notify_before_store : rl::test_suite<test_atomic_notify_before_store, 2, rl::test_result_deadlock>
+{
+    std::atomic<int> data;
+
+    void before()
+    {
+        data.store(0);
+    }
+
+    void thread(unsigned index)
+    {
+        if (0 == index)
+        {
+            data.wait(0);
+        }
+        else
+        {
+            data.notify_one();
+            data.store(1);
+        }
+    }
+};
+
+struct test_atomic_wait_wrong_value : rl::test_suite<test_atomic_wait_wrong_value, 2>
+{
+    std::atomic<int> data;
+
+    void before()
+    {
+        data.store(0);
+    }
+
+    void thread(unsigned index)
+    {
+        if (0 == index)
+        {
+            data.wait(1);
+        }
+        else
+        {
+            data.store(2);
+            data.notify_one();
+        }
+    }
+};
+
+struct test_atomic_circular_wait : rl::test_suite<test_atomic_circular_wait, 2, rl::test_result_deadlock>
+{
+    std::atomic<int> data1;
+    std::atomic<int> data2;
+
+    void before()
+    {
+        data1.store(0);
+        data2.store(0);
+    }
+
+    void thread(unsigned index)
+    {
+        if (0 == index)
+        {
+            data1.wait(0);
+            data2.store(1);
+            data2.notify_one();
+        }
+        else
+        {
+            data2.wait(0);
+            data1.store(1);
+            data1.notify_one();
+        }
+    }
+};
+
+struct test_atomic_notify_all_insufficient : rl::test_suite<test_atomic_notify_all_insufficient, 3, rl::test_result_deadlock>
+{
+    std::atomic<int> data;
+
+    void before()
+    {
+        data.store(0);
+    }
+
+    void thread(unsigned index)
+    {
+        if (index < 2)
+        {
+            data.wait(0);
+            data.wait(1);
+        }
+        else
+        {
+            data.store(1);
+            data.notify_all();
+        }
+    }
+};
+
+struct test_atomic_multiple_notify_one : rl::test_suite<test_atomic_multiple_notify_one, 3>
+{
+    std::atomic<int> data;
+
+    void before()
+    {
+        data.store(0);
+    }
+
+    void thread(unsigned index)
+    {
+        if (0 == index)
+        {
+            data($).wait(0);
+            RL_ASSERT(data.load() == 1);
+        }
+        else
+        {
+            // Multiple notifiers
+            data.store(1);
+            data.notify_one();
+        }
+    }
+};
+
+struct test_atomic_double_wait : rl::test_suite<test_atomic_double_wait, 2, rl::test_result_deadlock>
+{
+    std::atomic<int> data;
+
+    void before()
+    {
+        data.store(0);
+    }
+
+    void thread(unsigned index)
+    {
+        if (0 == index)
+        {
+            data.wait(0);
+            RL_ASSERT(data.load() == 1);
+            data.wait(1);
+        }
+        else
+        {
+            data.store(2);
+            data.store(1);
+            data.notify_one();
+        }
+    }
+};
+
+struct test_atomic_notify_all_empty : rl::test_suite<test_atomic_notify_all_empty, 1>
+{
+    std::atomic<int> data;
+
+    void before()
+    {
+        data.store(0);
+    }
+
+    void thread(unsigned index)
+    {
+        data.notify_all();
+        data.store(1);
+        data.notify_all();
+    }
+};
+
+struct test_atomic_three_threads_in_chain : rl::test_suite<test_atomic_three_threads_in_chain, 3>
+{
+    std::atomic<int> flag1;
+    std::atomic<int> flag2;
+    std::atomic<int> flag3;
+
+    void before()
+    {
+        flag1.store(0);
+        flag2.store(0);
+        flag3.store(0);
+    }
+
+    void thread(unsigned index)
+    {
+        if (0 == index)
+        {
+            flag1.wait(0);
+            flag2.store(1);
+            flag2.notify_one();
+        }
+        else if (1 == index)
+        {
+            flag2.wait(0);
+            flag3.store(1);
+            flag3.notify_one();
+        }
+        else
+        {
+            // Start the chain
+            flag1.store(1);
+            flag1.notify_one();
+            flag3.wait(0);
+        }
+    }
+};
+
+int main()
+{
+    rl::test_params params;
+    params.iteration_count = 10000;
+
+#define CHECK(x) if (!(x)) { std::cout << "Test failed at line " << __LINE__ << std::endl; return 1; }
+
+    CHECK(rl::simulate<test_atomic_wait_notify_basic>(params));
+    CHECK(rl::simulate<test_atomic_notify_one_insufficient>(params));
+    CHECK(rl::simulate<test_atomic_notify_all>(params));
+    CHECK(rl::simulate<test_atomic_wait_no_block>(params));
+    CHECK(rl::simulate<test_atomic_wait_notify_cycles>(params));
+    CHECK(rl::simulate<test_atomic_notify_no_waiters>(params));
+    CHECK(rl::simulate<test_atomic_wait_memory_order>(params));
+    CHECK(rl::simulate<test_atomic_racing_notifiers>(params));
+    CHECK(rl::simulate<test_atomic_wait_race>(params));
+    CHECK(rl::simulate<test_atomic_forgot_notify>(params));
+    CHECK(rl::simulate<test_atomic_notify_before_store>(params));
+    CHECK(rl::simulate<test_atomic_wait_wrong_value>(params));
+    CHECK(rl::simulate<test_atomic_circular_wait>(params));
+    CHECK(rl::simulate<test_atomic_notify_all_insufficient>(params));
+    CHECK(rl::simulate<test_atomic_multiple_notify_one>(params));
+    CHECK(rl::simulate<test_atomic_double_wait>(params));
+    CHECK(rl::simulate<test_atomic_notify_all_empty>(params));
+    CHECK(rl::simulate<test_atomic_three_threads_in_chain>(params));
+    
+    return 0;
+}
+
+#else
+
+int main() { return 0; }
+
+#endif

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,6 +1,11 @@
+#include "../relacy/fakestd/prologue.hpp"
 #include "stdafx.h"
 
 //#define RL_MSVC_OUTPUT
+
+#if __cplusplus < 202002L
+#define RELACY_ENABLE_MEMORY_ORDER_DEBUG_INFO_DEFAULTING
+#endif
 
 #include "../relacy/relacy_std.hpp"
 #include "memory_order.hpp"
@@ -441,7 +446,10 @@ int main()
         &rl::simulate<race_seq_st_ld_test>,
         &rl::simulate<race_seq_st_st_test>,
 
+        #if __cplusplus < 202002L
+        // C++20 std::atomic are always initialized, so this test is not applicable in C++20 or newer
         &rl::simulate<race_uninit_test>,
+        #endif
         &rl::simulate<race_indirect_test>,
 
         // compare_exchange

--- a/test/new_delete.cpp
+++ b/test/new_delete.cpp
@@ -1,5 +1,5 @@
-#include "../../relacy/relacy_std.hpp"
-#include "../../relacy/relacy_cli.hpp"
+#include "../relacy/relacy_std.hpp"
+#include "../relacy/relacy_cli.hpp"
 
 #include <vector>
 


### PR DESCRIPTION
 - Added more support for GCC12, 13, and 14 with libstdc++
 - Added support for C++20's std::atomic wait/notify* APIs.
 - Relacy no longer defines memory_order_* macros to insert the rl::debug_info
   with the current file/line information. In C++20 mode, Relacy uses
   std::source_location to do this automatically without relying on macros.
   As of this release, Relacy introduces RELACY_ENABLE_MEMORY_ORDER_DEBUG_INFO_DEFAULTING
   to allow using the older behavior, which should only be needed in pre-C++2