### PR TITLE
add installable package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,23 +1,65 @@
 cmake_minimum_required(VERSION 3.20)
 
 project(Relacy
+    VERSION 0.0.0
     LANGUAGES CXX
 )
 
-option(RELACY_BUILD_TESTS "Build Relacy tests" ON)
-option(RELACY_BUILD_EXAMPLES "Build Relacy examples" ON)
+option(RELACY_BUILD_TESTS "Build Relacy tests" ${PROJECT_IS_TOP_LEVEL})
+option(RELACY_BUILD_EXAMPLES "Build Relacy examples" ${PROJECT_IS_TOP_LEVEL})
+
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
 
 add_library(relacy INTERFACE)
+add_library(relacy::relacy ALIAS relacy)
 target_include_directories(relacy INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-    $<INSTALL_INTERFACE:include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
+target_compile_features(relacy INTERFACE cxx_std_11)
 
 add_library(relacy_fakestd INTERFACE)
 target_include_directories(relacy_fakestd INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/relacy/fakestd>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-    $<INSTALL_INTERFACE:include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
+set(RELACY_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/relacy")
+set(RELACY_PACKAGE_VERSION "${PROJECT_VERSION}")
+
+install(TARGETS relacy
+    EXPORT relacyTargets
+    INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+)
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/relacy/"
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/relacy"
+)
+
+install(EXPORT relacyTargets
+    NAMESPACE relacy::
+    FILE relacyTargets.cmake
+    DESTINATION "${RELACY_INSTALL_CMAKEDIR}"
+)
+
+configure_package_config_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/relacyConfig.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/relacyConfig.cmake"
+    INSTALL_DESTINATION "${RELACY_INSTALL_CMAKEDIR}"
+)
+
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/relacyConfigVersion.cmake"
+    VERSION "${RELACY_PACKAGE_VERSION}"
+    COMPATIBILITY ExactVersion
+    ARCH_INDEPENDENT
+)
+
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/relacyConfig.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/relacyConfigVersion.cmake"
+    DESTINATION "${RELACY_INSTALL_CMAKEDIR}"
 )
 
 function(add_relacy_test target_name source_file)

--- a/README.md
+++ b/README.md
@@ -34,6 +34,45 @@ make build-all -j 8
 make test-all -j 8
 ```
 
+## Installing and packaging Relacy with CMake
+
+Relacy can be installed as a header-only CMake package and then consumed with
+`find_package()` in Config mode.
+
+Install it with:
+
+```
+cmake -S . -B build \
+  -DCMAKE_CXX_STANDARD=20 \
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo
+cmake --build build
+cmake --install build --prefix /path/to/prefix
+```
+
+This installs:
+
+- headers under `/path/to/prefix/include/relacy`
+- package files under `/path/to/prefix/lib/cmake/relacy`
+
+In a downstream CMake project:
+
+```
+cmake_minimum_required(VERSION 3.20)
+project(my_relacy_app LANGUAGES CXX)
+
+find_package(relacy CONFIG REQUIRED)
+
+add_executable(my_relacy_app main.cpp)
+target_link_libraries(my_relacy_app PRIVATE relacy::relacy)
+```
+
+When configuring the downstream project, point CMake at the install prefix:
+
+```
+cmake -S . -B build -DCMAKE_PREFIX_PATH=/path/to/prefix
+cmake --build build
+```
+
 ## Toolchains known to work
 
 At a minimum, a C++11 compiler is assumed. The below compilers have

--- a/cmake/relacyConfig.cmake.in
+++ b/cmake/relacyConfig.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/relacyTargets.cmake")
+check_required_components(relacy)


### PR DESCRIPTION
edits cmake scripts to make `relacy` installable so that `find_package(relacy REQUIRED)` works.

# Test Plan

made a sample package (copied examples) and verify that relacy is found in a custom install prefix.